### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Needs react-native >= 0.14.2
 
 ![ui](./doc/ui.jpg)
 
-###Documentation
+### Documentation
 ```
 	title: PropTypes.string.isRequired,
 	//not include the height of statusBar on ios platform
@@ -25,15 +25,15 @@ Needs react-native >= 0.14.2
 	onRightButtonPress: PropTypes.func
 ```
 
-###Usage
+### Usage
 
-####Step 1 - install
+#### Step 1 - install
 
 ```
 	npm install react-native-navigation-bar --save
 ```
 
-####Step 2 - import and use in project
+#### Step 2 - import and use in project
 ```javascript
 	import NavigationBar from 'react-native-navigation-bar';
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
